### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
### Overview

- This PR adds a .gitignore file to exclude system files from the repository.
- The target for this .gitignore is the .DS_store file associated with the macOS
- This file can be updated to ignore files as required